### PR TITLE
fix tracer criteria for updraft identification

### DIFF
--- a/Tracers.pyx
+++ b/Tracers.pyx
@@ -981,7 +981,7 @@ cdef updraft_indicator_sc_w_ql(Grid.DimStruct *dims,  double *tracer_raw, double
                     for j in xrange(dims.nlg[1]):
                         jshift = j*jstride
                         ijk = ishift + jshift + k
-                        tracer_normed[ijk] = 0.0
+                        tracer_normed[ijk] = copysign( (tracer_raw[ijk] - mean[k])/ sigma_min, w_half)
             else:
                for i in xrange(dims.nlg[0]):
                     ishift = i*istride

--- a/Tracers.pyx
+++ b/Tracers.pyx
@@ -906,7 +906,7 @@ cdef updraft_indicator_sc(Grid.DimStruct *dims, double *tracer_raw, double *trac
                     for j in xrange(jmax):
                         jshift = j*jstride
                         ijk = ishift + jshift + k
-                        tracer_normed[ijk] = 0.0
+                        tracer_normed[ijk] = (tracer_raw[ijk] - mean[k])/ sigma_min
             else:
                for i in xrange(imax):
                     ishift = i*istride
@@ -945,7 +945,7 @@ cdef updraft_indicator_sc_w(Grid.DimStruct *dims, double *tracer_raw, double *tr
                     for j in xrange(jmax):
                         jshift = j*jstride
                         ijk = ishift + jshift + k
-                        tracer_normed[ijk] = 0.0
+                        tracer_normed[ijk] = copysign( (tracer_raw[ijk] - mean[k])/ sigma_min, w_half)
             else:
                for i in xrange(imax):
                     ishift = i*istride


### PR DESCRIPTION
In the Couvreux paper, tracer criterion is tracer_consentration > 1*max(tracer_std, sig_min).

A problem in the current Trace.pyx:

If tracer_std < sig_min, it is set to environment without comparing tracer_consentration with sig_min. 

By computing tracer_normed as (tracer_raw - mean)/sig_min, a comparison between tracer_consentration with sig_min is added when comparing tracer_normed with 1.0 in assigning updraft_indicator