### PR TITLE
Fix the diagnostic variable for the perturbation pressure 

### DIFF
--- a/AuxiliaryStatistics.pyx
+++ b/AuxiliaryStatistics.pyx
@@ -455,7 +455,7 @@ class TKEStatistics:
             Py_ssize_t v_shift = PV.get_varshift(Gr, 'v')
             Py_ssize_t w_shift = PV.get_varshift(Gr, 'w')
             Py_ssize_t b_shift = DV.get_varshift(Gr,'buoyancy')
-            Py_ssize_t p_shift = DV.get_varshift(Gr, 'dynamic_pressure')
+            Py_ssize_t p_shift = DV.get_varshift(Gr, 'density_dynamic_pressure')
             Py_ssize_t visc_shift = DV.get_varshift(Gr, 'viscosity')
 
             double [:] uc = np.zeros(Gr.dims.nlg[0]* Gr.dims.nlg[1]* Gr.dims.nlg[2], dtype=np.double, order='c')

--- a/AuxiliaryStatistics.pyx
+++ b/AuxiliaryStatistics.pyx
@@ -455,7 +455,7 @@ class TKEStatistics:
             Py_ssize_t v_shift = PV.get_varshift(Gr, 'v')
             Py_ssize_t w_shift = PV.get_varshift(Gr, 'w')
             Py_ssize_t b_shift = DV.get_varshift(Gr,'buoyancy')
-            Py_ssize_t p_shift = DV.get_varshift(Gr, 'density_perturbation_pressure')
+            Py_ssize_t p_shift = DV.get_varshift(Gr, 'perturbation_pressure_potential')
             Py_ssize_t visc_shift = DV.get_varshift(Gr, 'viscosity')
 
             double [:] uc = np.zeros(Gr.dims.nlg[0]* Gr.dims.nlg[1]* Gr.dims.nlg[2], dtype=np.double, order='c')

--- a/AuxiliaryStatistics.pyx
+++ b/AuxiliaryStatistics.pyx
@@ -455,7 +455,7 @@ class TKEStatistics:
             Py_ssize_t v_shift = PV.get_varshift(Gr, 'v')
             Py_ssize_t w_shift = PV.get_varshift(Gr, 'w')
             Py_ssize_t b_shift = DV.get_varshift(Gr,'buoyancy')
-            Py_ssize_t p_shift = DV.get_varshift(Gr, 'density_dynamic_pressure')
+            Py_ssize_t p_shift = DV.get_varshift(Gr, 'density_perturbation_pressure')
             Py_ssize_t visc_shift = DV.get_varshift(Gr, 'viscosity')
 
             double [:] uc = np.zeros(Gr.dims.nlg[0]* Gr.dims.nlg[1]* Gr.dims.nlg[2], dtype=np.double, order='c')

--- a/PressureFFTParallel.pyx
+++ b/PressureFFTParallel.pyx
@@ -158,7 +158,7 @@ cdef class PressureFFTParallel:
             double [:] dkr = np.empty((Gr.dims.nl[2]),dtype=np.double,order='c')
             double [:] dki = np.empty((Gr.dims.nl[2]),dtype=np.double,order='c')
             Py_ssize_t div_shift = DV.get_varshift(Gr,'divergence')
-            Py_ssize_t pres_shift = DV.get_varshift(Gr,'dynamic_pressure')
+            Py_ssize_t pres_shift = DV.get_varshift(Gr,'density_dynamic_pressure')
             Py_ssize_t p, pencil_i, pencil_j
             Py_ssize_t count = 0
             Py_ssize_t pencil_shift = 0 #self.Z_Pencil.n_pencil_map[self.Z_Pencil.rank - 1]

--- a/PressureFFTParallel.pyx
+++ b/PressureFFTParallel.pyx
@@ -158,7 +158,7 @@ cdef class PressureFFTParallel:
             double [:] dkr = np.empty((Gr.dims.nl[2]),dtype=np.double,order='c')
             double [:] dki = np.empty((Gr.dims.nl[2]),dtype=np.double,order='c')
             Py_ssize_t div_shift = DV.get_varshift(Gr,'divergence')
-            Py_ssize_t pres_shift = DV.get_varshift(Gr,'density_perturbation_pressure')
+            Py_ssize_t pres_shift = DV.get_varshift(Gr,'perturbation_pressure_potential')
             Py_ssize_t p, pencil_i, pencil_j
             Py_ssize_t count = 0
             Py_ssize_t pencil_shift = 0 #self.Z_Pencil.n_pencil_map[self.Z_Pencil.rank - 1]

--- a/PressureFFTParallel.pyx
+++ b/PressureFFTParallel.pyx
@@ -158,7 +158,7 @@ cdef class PressureFFTParallel:
             double [:] dkr = np.empty((Gr.dims.nl[2]),dtype=np.double,order='c')
             double [:] dki = np.empty((Gr.dims.nl[2]),dtype=np.double,order='c')
             Py_ssize_t div_shift = DV.get_varshift(Gr,'divergence')
-            Py_ssize_t pres_shift = DV.get_varshift(Gr,'density_dynamic_pressure')
+            Py_ssize_t pres_shift = DV.get_varshift(Gr,'density_perturbation_pressure')
             Py_ssize_t p, pencil_i, pencil_j
             Py_ssize_t count = 0
             Py_ssize_t pencil_shift = 0 #self.Z_Pencil.n_pencil_map[self.Z_Pencil.rank - 1]

--- a/PressureFFTSerial.pyx
+++ b/PressureFFTSerial.pyx
@@ -172,7 +172,7 @@ cdef class PressureFFTSerial:
 
         cdef:
             double [:,:,:] p = ifft2(div_fft,axes=(0,1)).real
-            Py_ssize_t pres_shift = DV.get_varshift(Gr,'density_perturbation_pressure')
+            Py_ssize_t pres_shift = DV.get_varshift(Gr,'perturbation_pressure_potential')
 
 
         with nogil:

--- a/PressureFFTSerial.pyx
+++ b/PressureFFTSerial.pyx
@@ -172,7 +172,7 @@ cdef class PressureFFTSerial:
 
         cdef:
             double [:,:,:] p = ifft2(div_fft,axes=(0,1)).real
-            Py_ssize_t pres_shift = DV.get_varshift(Gr,'dynamic_pressure')
+            Py_ssize_t pres_shift = DV.get_varshift(Gr,'density_dynamic_pressure')
 
 
         with nogil:

--- a/PressureFFTSerial.pyx
+++ b/PressureFFTSerial.pyx
@@ -172,7 +172,7 @@ cdef class PressureFFTSerial:
 
         cdef:
             double [:,:,:] p = ifft2(div_fft,axes=(0,1)).real
-            Py_ssize_t pres_shift = DV.get_varshift(Gr,'density_dynamic_pressure')
+            Py_ssize_t pres_shift = DV.get_varshift(Gr,'density_perturbation_pressure')
 
 
         with nogil:

--- a/PressureSolver.pyx
+++ b/PressureSolver.pyx
@@ -28,8 +28,8 @@ cdef class PressureSolver:
         DV.add_variables('perturbation_pressure_potential', 'm^2 s^-2', r'p', 'density dynamic pressure', 'sym', PM)
         DV.add_variables('divergence', '1/s', r'd', '3d divergence', 'sym',PM)
 
-        DV.add_variables('wBudget_PressureGradient', 'm/s, r'pgrad', 'pressure gradient', 'sym', PM)
-        DV.add_variables('wBudget_PressureGradient_RK0', 'm/s, r'pgrad', 'pressure gradient', 'sym', PM)
+        DV.add_variables('wBudget_PressureGradient', 'm/s', r'pgrad', 'pressure gradient', 'sym', PM)
+        DV.add_variables('wBudget_PressureGradient_RK0', 'm/s', r'pgrad', 'pressure gradient', 'sym', PM)
         DV.add_variables('wBudget_PressureGradient_RK1', 'm/s', r'pgrad', 'pressure gradient', 'sym', PM)
         DV.add_variables('wBudget_PressureGradient_RK2', 'm/s', r'pgrad', 'pressure gradient', 'sym', PM)
         DV.add_variables('wBudget_PressureGradient_RK3', 'm/s', r'pgrad', 'pressure gradient', 'sym', PM)

--- a/PressureSolver.pyx
+++ b/PressureSolver.pyx
@@ -25,7 +25,7 @@ cdef class PressureSolver:
 
     cpdef initialize(self,namelist, Grid.Grid Gr,ReferenceState.ReferenceState RS ,DiagnosticVariables.DiagnosticVariables DV, ParallelMPI.ParallelMPI PM):
 
-        DV.add_variables('density_dynamic_pressure', 'm^2 s^-2', r'p', 'density dynamic pressure', 'sym', PM)
+        DV.add_variables('density_perturbation_pressure', 'm^2 s^-2', r'p', 'density dynamic pressure', 'sym', PM)
         DV.add_variables('divergence', '1/s', r'd', '3d divergence', 'sym',PM)
 
         DV.add_variables('wBudget_PressureGradient', 'm/s, r'pgrad', 'pressure gradient', 'sym', PM)
@@ -56,7 +56,7 @@ cdef class PressureSolver:
             Py_ssize_t u_shift = PV.get_varshift(Gr,'u')
             Py_ssize_t v_shift = PV.get_varshift(Gr,'v')
             Py_ssize_t w_shift = PV.get_varshift(Gr,'w')
-            Py_ssize_t pres_shift = DV.get_varshift(Gr,'density_dynamic_pressure')
+            Py_ssize_t pres_shift = DV.get_varshift(Gr,'density_perturbation_pressure')
             Py_ssize_t div_shift = DV.get_varshift(Gr,'divergence')
 
             Py_ssize_t dpdz_shift = DV.get_varshift(Gr,'wBudget_PressureGradient')
@@ -82,7 +82,7 @@ cdef class PressureSolver:
         self.poisson_solver.solve(Gr, RS, DV, PM)
 
         #Update pressure boundary condition
-        p_nv = DV.name_index['density_dynamic_pressure']
+        p_nv = DV.name_index['density_perturbation_pressure']
         DV.communicate_variable(Gr,PM,p_nv)
 
         #Apply pressure correction

--- a/PressureSolver.pyx
+++ b/PressureSolver.pyx
@@ -25,8 +25,19 @@ cdef class PressureSolver:
 
     cpdef initialize(self,namelist, Grid.Grid Gr,ReferenceState.ReferenceState RS ,DiagnosticVariables.DiagnosticVariables DV, ParallelMPI.ParallelMPI PM):
 
-        DV.add_variables('dynamic_pressure', 'Pa', r'p', 'dynamic pressure', 'sym', PM)
+        DV.add_variables('density_dynamic_pressure', 'm^2 s^-2', r'p', 'density dynamic pressure', 'sym', PM)
         DV.add_variables('divergence', '1/s', r'd', '3d divergence', 'sym',PM)
+
+        DV.add_variables('wBudget_PressureGradient', 'm/s, r'pgrad', 'pressure gradient', 'sym', PM)
+        DV.add_variables('wBudget_PressureGradient_RK0', 'm/s, r'pgrad', 'pressure gradient', 'sym', PM)
+        DV.add_variables('wBudget_PressureGradient_RK1', 'm/s', r'pgrad', 'pressure gradient', 'sym', PM)
+        DV.add_variables('wBudget_PressureGradient_RK2', 'm/s', r'pgrad', 'pressure gradient', 'sym', PM)
+        DV.add_variables('wBudget_PressureGradient_RK3', 'm/s', r'pgrad', 'pressure gradient', 'sym', PM)
+        DV.add_variables('wBudget_removeHorAve', 'm/s', r'pgrad', 'pressure gradient', 'sym', PM)
+        DV.add_variables('wBudget_removeHorAve_RK0', 'm/s', r'pgrad', 'pressure gradient', 'sym', PM)
+        DV.add_variables('wBudget_removeHorAve_RK1', 'm/s', r'pgrad', 'pressure gradient', 'sym', PM)
+        DV.add_variables('wBudget_removeHorAve_RK2', 'm/s', r'pgrad', 'pressure gradient', 'sym', PM)
+        DV.add_variables('wBudget_removeHorAve_RK3', 'm/s', r'pgrad', 'pressure gradient', 'sym', PM)
 
         self.divergence = np.zeros(Gr.dims.npl,dtype=np.double, order='c')
         #self.poisson_solver = PressureFFTSerial.PressureFFTSerial()
@@ -45,13 +56,16 @@ cdef class PressureSolver:
             Py_ssize_t u_shift = PV.get_varshift(Gr,'u')
             Py_ssize_t v_shift = PV.get_varshift(Gr,'v')
             Py_ssize_t w_shift = PV.get_varshift(Gr,'w')
-            Py_ssize_t pres_shift = DV.get_varshift(Gr,'dynamic_pressure')
+            Py_ssize_t pres_shift = DV.get_varshift(Gr,'density_dynamic_pressure')
             Py_ssize_t div_shift = DV.get_varshift(Gr,'divergence')
+
+            Py_ssize_t dpdz_shift = DV.get_varshift(Gr,'wBudget_PressureGradient')
+            Py_ssize_t whor_shift = DV.get_varshift(Gr,'wBudget_removeHorAve')
 
 
         #Remove mean u3
         cdef double [:] u3_mean = PM.HorizontalMean(Gr,&PV.values[w_shift])
-        remove_mean_u3(&Gr.dims,&u3_mean[0],&PV.values[w_shift])
+        remove_mean_u3(&Gr.dims,&u3_mean[0],&PV.values[w_shift],&DV.values[whor_shift])
 
         #Zero the divergence array [Perhaps we can replace this with a C-Call to Memset]
         with nogil:
@@ -68,19 +82,19 @@ cdef class PressureSolver:
         self.poisson_solver.solve(Gr, RS, DV, PM)
 
         #Update pressure boundary condition
-        p_nv = DV.name_index['dynamic_pressure']
+        p_nv = DV.name_index['density_dynamic_pressure']
         DV.communicate_variable(Gr,PM,p_nv)
 
         #Apply pressure correction
         second_order_pressure_correction(&Gr.dims,&DV.values[pres_shift],
-                                         &PV.values[u_shift],&PV.values[v_shift],&PV.values[w_shift])
+                                         &PV.values[u_shift],&PV.values[v_shift],&PV.values[w_shift],&DV.values[dpdz_shift])
 
         #Switch this call at for a single variable boundary condition update
         PV.update_all_bcs(Gr,PM)
 
         return
 
-cdef void second_order_pressure_correction(Grid.DimStruct *dims, double *p, double *u, double *v, double *w ):
+cdef void second_order_pressure_correction(Grid.DimStruct *dims, double *p, double *u, double *v, double *w ,double *press_grad ):
 
     cdef:
         Py_ssize_t imin = 0
@@ -106,11 +120,12 @@ cdef void second_order_pressure_correction(Grid.DimStruct *dims, double *p, doub
                 u[ijk] -=  (p[ijk + ip1] - p[ijk])*dims.dxi[0]
                 v[ijk] -=  (p[ijk + jp1] - p[ijk])*dims.dxi[1]
                 w[ijk] -=  (p[ijk + kp1] - p[ijk])*dims.dxi[2]  #(p[ijk + kp1] - p[ijk])*dims.dxi[2]
+                press_grad[ijk] = -(p[ijk + kp1] - p[ijk])*dims.dxi[2]
 
     return
 
 
-cdef void remove_mean_u3(Grid.DimStruct *dims, double *u3_mean, double *velocity):
+cdef void remove_mean_u3(Grid.DimStruct *dims, double *u3_mean, double *velocity, double *whor):
 
     cdef:
         Py_ssize_t imin = 0
@@ -132,6 +147,7 @@ cdef void remove_mean_u3(Grid.DimStruct *dims, double *u3_mean, double *velocity
                 for k in xrange(kmin,kmax):
                      ijk = ishift + jshift + k
                      velocity[ijk] = velocity[ijk] - u3_mean[k]
+                     whor[ijk] = -u3_mean[k]
 
     return
 

--- a/PressureSolver.pyx
+++ b/PressureSolver.pyx
@@ -33,11 +33,13 @@ cdef class PressureSolver:
         DV.add_variables('wBudget_PressureGradient_RK1', 'm/s', r'pgrad', 'pressure gradient', 'sym', PM)
         DV.add_variables('wBudget_PressureGradient_RK2', 'm/s', r'pgrad', 'pressure gradient', 'sym', PM)
         DV.add_variables('wBudget_PressureGradient_RK3', 'm/s', r'pgrad', 'pressure gradient', 'sym', PM)
+        DV.add_variables('wBudget_PressureGradient_RK4', 'm/s', r'pgrad', 'pressure gradient', 'sym', PM)
         DV.add_variables('wBudget_removeHorAve', 'm/s', r'pgrad', 'pressure gradient', 'sym', PM)
         DV.add_variables('wBudget_removeHorAve_RK0', 'm/s', r'pgrad', 'pressure gradient', 'sym', PM)
         DV.add_variables('wBudget_removeHorAve_RK1', 'm/s', r'pgrad', 'pressure gradient', 'sym', PM)
         DV.add_variables('wBudget_removeHorAve_RK2', 'm/s', r'pgrad', 'pressure gradient', 'sym', PM)
         DV.add_variables('wBudget_removeHorAve_RK3', 'm/s', r'pgrad', 'pressure gradient', 'sym', PM)
+        DV.add_variables('wBudget_removeHorAve_RK4', 'm/s', r'pgrad', 'pressure gradient', 'sym', PM)
 
         self.divergence = np.zeros(Gr.dims.npl,dtype=np.double, order='c')
         #self.poisson_solver = PressureFFTSerial.PressureFFTSerial()

--- a/Simulation3d.pyx
+++ b/Simulation3d.pyx
@@ -176,6 +176,7 @@ class Simulation3d:
                 self.TS.update(self.Gr, self.PV, self.Pa)
                 PV_.Update_all_bcs(self.Gr, self.Pa)
                 self.Pr.update(self.Gr, self.Ref, self.DV, self.PV, self.Pa)
+                self.TS.update_pressure(self.Gr, self.PV, self.DV, self.Pa)
                 self.TS.adjust_timestep(self.Gr, self.PV, self.DV,self.Pa)
                 self.io()
                 #PV_.debug(self.Gr,self.Ref,self.StatsIO,self.Pa)
@@ -322,4 +323,3 @@ class Simulation3d:
         self.Aux.stats_io(self.Gr, self.Ref, self.PV, self.DV, self.MA, self.MD, self.StatsIO, self.Pa)
         self.StatsIO.close_files(self.Pa)
         return
-

--- a/TimeStepping.pxd
+++ b/TimeStepping.pxd
@@ -13,6 +13,7 @@ cdef class TimeStepping:
         public double dt_max
         public double dt_initial
         public double t_max
+        public double statIOdt
         double [:,:] value_copies
         double [:,:] tendency_copies
         public Py_ssize_t rk_step

--- a/TimeStepping.pxd
+++ b/TimeStepping.pxd
@@ -25,9 +25,13 @@ cdef class TimeStepping:
 
     cpdef initialize(self, namelist, PrognosticVariables.PrognosticVariables PV, ParallelMPI.ParallelMPI Pa)
     cpdef update(self,Grid.Grid Gr, PrognosticVariables.PrognosticVariables PV, ParallelMPI.ParallelMPI Pa)
+    cpdef update_pressure(self,Grid.Grid Gr, PrognosticVariables.PrognosticVariables PV, DiagnosticVariables.DiagnosticVariables DV, ParallelMPI.ParallelMPI Pa)
     cpdef update_second(self,Grid.Grid Gr, PrognosticVariables.PrognosticVariables PV)
     cpdef update_third(self,Grid.Grid Gr, PrognosticVariables.PrognosticVariables PV)
     cpdef update_fourth(self,Grid.Grid Gr, PrognosticVariables.PrognosticVariables PV)
+    cpdef update_pressure_second(self, Grid.Grid Gr, PrognosticVariables.PrognosticVariables PV, DiagnosticVariables.DiagnosticVariables DV)
+    cpdef update_pressure_third(self, Grid.Grid Gr, PrognosticVariables.PrognosticVariables PV, DiagnosticVariables.DiagnosticVariables DV)
+    cpdef update_pressure_fourth(self, Grid.Grid Gr, PrognosticVariables.PrognosticVariables PV, DiagnosticVariables.DiagnosticVariables DV)
 
     cpdef adjust_timestep(self,Grid.Grid Gr, PrognosticVariables.PrognosticVariables PV, DiagnosticVariables.DiagnosticVariables DV, ParallelMPI.ParallelMPI Pa)
     cdef void compute_cfl_max(self,Grid.Grid Gr, PrognosticVariables.PrognosticVariables PV, DiagnosticVariables.DiagnosticVariables DV,ParallelMPI.ParallelMPI Pa)

--- a/TimeStepping.pyx
+++ b/TimeStepping.pyx
@@ -62,6 +62,8 @@ cdef class TimeStepping:
             Pa.root_print('t_max (time at end of simulation) not given in name list! Killing Simulation Now')
             Pa.kill()
 
+        
+
         #Now initialize the correct time stepping routine
         if self.ts_type == 2:
             self.initialize_second(PV)
@@ -145,7 +147,7 @@ cdef class TimeStepping:
     cpdef update_pressure_second(self, Grid.Grid Gr, PrognosticVariables.PrognosticVariables PV, DiagnosticVariables.DiagnosticVariables DV):
         cdef:
             Py_ssize_t i
-            Py_ssize_t press_shift = DV.get_varshift(Gr, 'density_perturbation_pressure')
+            Py_ssize_t press_shift = DV.get_varshift(Gr, 'perturbation_pressure_potential')
 
             Py_ssize_t whor_shift = DV.get_varshift(Gr, 'wBudget_removeHorAve')
             Py_ssize_t whor_rk0_shift = DV.get_varshift(Gr, 'wBudget_removeHorAve_RK0')
@@ -206,7 +208,7 @@ cdef class TimeStepping:
     cpdef update_pressure_third(self, Grid.Grid Gr, PrognosticVariables.PrognosticVariables PV, DiagnosticVariables.DiagnosticVariables DV):
         cdef:
             Py_ssize_t i
-            Py_ssize_t press_shift = DV.get_varshift(Gr, 'density_perturbation_pressure')
+            Py_ssize_t press_shift = DV.get_varshift(Gr, 'perturbation_pressure_potential')
 
             Py_ssize_t whor_shift = DV.get_varshift(Gr, 'wBudget_removeHorAve')
             Py_ssize_t whor_rk0_shift = DV.get_varshift(Gr, 'wBudget_removeHorAve_RK0')
@@ -292,7 +294,7 @@ cdef class TimeStepping:
     cpdef update_pressure_fourth(self, Grid.Grid Gr, PrognosticVariables.PrognosticVariables PV, DiagnosticVariables.DiagnosticVariables DV):
         cdef:
             Py_ssize_t i
-            Py_ssize_t press_shift = DV.get_varshift(Gr, 'density_perturbation_pressure')
+            Py_ssize_t press_shift = DV.get_varshift(Gr, 'perturbation_pressure_potential')
 
             Py_ssize_t whor_shift = DV.get_varshift(Gr, 'wBudget_removeHorAve')
             Py_ssize_t whor_rk0_shift = DV.get_varshift(Gr, 'wBudget_removeHorAve_RK0')

--- a/TimeStepping.pyx
+++ b/TimeStepping.pyx
@@ -145,7 +145,7 @@ cdef class TimeStepping:
     cpdef update_pressure_second(self, Grid.Grid Gr, PrognosticVariables.PrognosticVariables PV, DiagnosticVariables.DiagnosticVariables DV):
         cdef:
             Py_ssize_t i
-            Py_ssize_t press_shift = DV.get_varshift(Gr, 'density_dynamic_pressure')
+            Py_ssize_t press_shift = DV.get_varshift(Gr, 'density_perturbation_pressure')
 
             Py_ssize_t whor_shift = DV.get_varshift(Gr, 'wBudget_removeHorAve')
             Py_ssize_t whor_rk0_shift = DV.get_varshift(Gr, 'wBudget_removeHorAve_RK0')
@@ -206,7 +206,7 @@ cdef class TimeStepping:
     cpdef update_pressure_third(self, Grid.Grid Gr, PrognosticVariables.PrognosticVariables PV, DiagnosticVariables.DiagnosticVariables DV):
         cdef:
             Py_ssize_t i
-            Py_ssize_t press_shift = DV.get_varshift(Gr, 'density_dynamic_pressure')
+            Py_ssize_t press_shift = DV.get_varshift(Gr, 'density_perturbation_pressure')
 
             Py_ssize_t whor_shift = DV.get_varshift(Gr, 'wBudget_removeHorAve')
             Py_ssize_t whor_rk0_shift = DV.get_varshift(Gr, 'wBudget_removeHorAve_RK0')
@@ -292,7 +292,7 @@ cdef class TimeStepping:
     cpdef update_pressure_fourth(self, Grid.Grid Gr, PrognosticVariables.PrognosticVariables PV, DiagnosticVariables.DiagnosticVariables DV):
         cdef:
             Py_ssize_t i
-            Py_ssize_t press_shift = DV.get_varshift(Gr, 'density_dynamic_pressure')
+            Py_ssize_t press_shift = DV.get_varshift(Gr, 'density_perturbation_pressure')
 
             Py_ssize_t whor_shift = DV.get_varshift(Gr, 'wBudget_removeHorAve')
             Py_ssize_t whor_rk0_shift = DV.get_varshift(Gr, 'wBudget_removeHorAve_RK0')

--- a/TimeStepping.pyx
+++ b/TimeStepping.pyx
@@ -165,15 +165,11 @@ cdef class TimeStepping:
         with nogil:
             if self.rk_step == 0:
                 if self.t % self.statIOdt == 0.0:
-                    DV.values[whor_rk0_shift:whor_rk0_shift+Gr.dims.npg] = 0.0
-                    DV.values[wpress_rk0_shift:wpress_rk0_shift+Gr.dims.npg] = 0.0
-                    DV.values[whor_rk1_shift:whor_rk1_shift+Gr.dims.npg] = 0.0
-                    DV.values[wpress_rk1_shift:wpress_rk1_shift+Gr.dims.npg] = 0.0
-                    # for i in xrange(Gr.dims.npg):
-                    #     DV.values[whor_rk0_shift+i] = 0.0
-                    #     DV.values[wpress_rk0_shift+i] = 0.0
-                    #     DV.values[whor_rk1_shift+i] = 0.0
-                    #     DV.values[wpress_rk1_shift+i] = 0.0
+                    for i in xrange(Gr.dims.npg):
+                        DV.values[whor_rk0_shift+i] = 0.0
+                        DV.values[wpress_rk0_shift+i] = 0.0
+                        DV.values[whor_rk1_shift+i] = 0.0
+                        DV.values[wpress_rk1_shift+i] = 0.0
 
                 for i in xrange(Gr.dims.npg):
                     DV.values[whor_rk0_shift+i] += DV.values[whor_shift+i]
@@ -231,19 +227,13 @@ cdef class TimeStepping:
         with nogil:
             if self.rk_step == 0:
                 if self.t % self.statIOdt == 0.0:
-                    DV.values[whor_rk0_shift:whor_rk0_shift+Gr.dims.npg] = 0.0
-                    DV.values[wpress_rk0_shift:wpress_rk0_shift+Gr.dims.npg] = 0.0
-                    DV.values[whor_rk1_shift:whor_rk1_shift+Gr.dims.npg] = 0.0
-                    DV.values[wpress_rk01_shift:wpress_rk1_shift+Gr.dims.npg] = 0.0
-                    DV.values[whor_rk2_shift:whor_rk2_shift+Gr.dims.npg] = 0.0
-                    DV.values[wpress_rk02_shift:wpress_rk2_shift+Gr.dims.npg] = 0.0
-                    # for i in xrange(Gr.dims.npg):
-                    #     DV.values[whor_rk0_shift+i] = 0.0
-                    #     DV.values[wpress_rk0_shift+i] = 0.0
-                    #     DV.values[whor_rk1_shift+i] = 0.0
-                    #     DV.values[wpress_rk1_shift+i] = 0.0
-                    #     DV.values[whor_rk2_shift+i] = 0.0
-                    #     DV.values[wpress_rk2_shift+i] = 0.0
+                    for i in xrange(Gr.dims.npg):
+                        DV.values[whor_rk0_shift+i] = 0.0
+                        DV.values[wpress_rk0_shift+i] = 0.0
+                        DV.values[whor_rk1_shift+i] = 0.0
+                        DV.values[wpress_rk1_shift+i] = 0.0
+                        DV.values[whor_rk2_shift+i] = 0.0
+                        DV.values[wpress_rk2_shift+i] = 0.0
 
                 for i in xrange(Gr.dims.npg):
                     DV.values[whor_rk0_shift+i] += DV.values[whor_shift+i]
@@ -334,23 +324,17 @@ cdef class TimeStepping:
         with nogil:
             if self.rk_step == 0:
                 if self.t % self.statIOdt == 0.0:
-                    DV.values[whor_rk0_shift:whor_rk0_shift+Gr.dims.npg] = 0.0
-                    DV.values[wpress_rk0_shift:wpress_rk0_shift+Gr.dims.npg] = 0.0
-                    DV.values[whor_rk1_shift:whor_rk1_shift+Gr.dims.npg] = 0.0
-                    DV.values[wpress_rk01_shift:wpress_rk1_shift+Gr.dims.npg] = 0.0
-                    DV.values[whor_rk2_shift:whor_rk2_shift+Gr.dims.npg] = 0.0
-                    DV.values[wpress_rk02_shift:wpress_rk2_shift+Gr.dims.npg] = 0.0
-                    DV.values[whor_rk3_shift:whor_rk3_shift+Gr.dims.npg] = 0.0
-                    DV.values[wpress_rk03_shift:wpress_rk3_shift+Gr.dims.npg] = 0.0
-                    DV.values[whor_rk4_shift:whor_rk4_shift+Gr.dims.npg] = 0.0
-                    DV.values[wpress_rk04_shift:wpress_rk4_shift+Gr.dims.npg] = 0.0
-                    # for i in xrange(Gr.dims.npg):
-                    #     DV.values[whor_rk0_shift+i] = 0.0
-                    #     DV.values[wpress_rk0_shift+i] = 0.0
-                    #     DV.values[whor_rk1_shift+i] = 0.0
-                    #     DV.values[wpress_rk1_shift+i] = 0.0
-                    #     DV.values[whor_rk2_shift+i] = 0.0
-                    #     DV.values[wpress_rk2_shift+i] = 0.0
+                    for i in xrange(Gr.dims.npg):
+                        DV.values[whor_rk0_shift+i] = 0.0
+                        DV.values[wpress_rk0_shift+i] = 0.0
+                        DV.values[whor_rk1_shift+i] = 0.0
+                        DV.values[wpress_rk1_shift+i] = 0.0
+                        DV.values[whor_rk2_shift+i] = 0.0
+                        DV.values[wpress_rk2_shift+i] = 0.0
+                        DV.values[whor_rk3_shift+i] = 0.0
+                        DV.values[whor_rk3_shift+i] = 0.0
+                        DV.values[wpress_rk4_shift+i] = 0.0
+                        DV.values[wpress_rk4_shift+i] = 0.0
 
                 for i in xrange(Gr.dims.npg):
                     DV.values[whor_rk0_shift+i] += DV.values[whor_shift+i]

--- a/TimeStepping.pyx
+++ b/TimeStepping.pyx
@@ -165,11 +165,15 @@ cdef class TimeStepping:
         with nogil:
             if self.rk_step == 0:
                 if self.t % self.statIOdt == 0.0:
-                    for i in xrange(Gr.dims.npg):
-                        DV.values[whor_rk0_shift+i] = 0.0
-                        DV.values[wpress_rk0_shift+i] = 0.0
-                        DV.values[whor_rk1_shift+i] = 0.0
-                        DV.values[wpress_rk1_shift+i] = 0.0
+                    DV.values[whor_rk0_shift:whor_rk0_shift+Gr.dims.npg] = 0.0
+                    DV.values[wpress_rk0_shift:wpress_rk0_shift+Gr.dims.npg] = 0.0
+                    DV.values[whor_rk1_shift:whor_rk1_shift+Gr.dims.npg] = 0.0
+                    DV.values[wpress_rk1_shift:wpress_rk1_shift+Gr.dims.npg] = 0.0
+                    # for i in xrange(Gr.dims.npg):
+                    #     DV.values[whor_rk0_shift+i] = 0.0
+                    #     DV.values[wpress_rk0_shift+i] = 0.0
+                    #     DV.values[whor_rk1_shift+i] = 0.0
+                    #     DV.values[wpress_rk1_shift+i] = 0.0
 
                 for i in xrange(Gr.dims.npg):
                     DV.values[whor_rk0_shift+i] += DV.values[whor_shift+i]
@@ -227,13 +231,19 @@ cdef class TimeStepping:
         with nogil:
             if self.rk_step == 0:
                 if self.t % self.statIOdt == 0.0:
-                    for i in xrange(Gr.dims.npg):
-                        DV.values[whor_rk0_shift+i] = 0.0
-                        DV.values[wpress_rk0_shift+i] = 0.0
-                        DV.values[whor_rk1_shift+i] = 0.0
-                        DV.values[wpress_rk1_shift+i] = 0.0
-                        DV.values[whor_rk2_shift+i] = 0.0
-                        DV.values[wpress_rk2_shift+i] = 0.0
+                    DV.values[whor_rk0_shift:whor_rk0_shift+Gr.dims.npg] = 0.0
+                    DV.values[wpress_rk0_shift:wpress_rk0_shift+Gr.dims.npg] = 0.0
+                    DV.values[whor_rk1_shift:whor_rk1_shift+Gr.dims.npg] = 0.0
+                    DV.values[wpress_rk01_shift:wpress_rk1_shift+Gr.dims.npg] = 0.0
+                    DV.values[whor_rk2_shift:whor_rk2_shift+Gr.dims.npg] = 0.0
+                    DV.values[wpress_rk02_shift:wpress_rk2_shift+Gr.dims.npg] = 0.0
+                    # for i in xrange(Gr.dims.npg):
+                    #     DV.values[whor_rk0_shift+i] = 0.0
+                    #     DV.values[wpress_rk0_shift+i] = 0.0
+                    #     DV.values[whor_rk1_shift+i] = 0.0
+                    #     DV.values[wpress_rk1_shift+i] = 0.0
+                    #     DV.values[whor_rk2_shift+i] = 0.0
+                    #     DV.values[wpress_rk2_shift+i] = 0.0
 
                 for i in xrange(Gr.dims.npg):
                     DV.values[whor_rk0_shift+i] += DV.values[whor_shift+i]
@@ -324,13 +334,23 @@ cdef class TimeStepping:
         with nogil:
             if self.rk_step == 0:
                 if self.t % self.statIOdt == 0.0:
-                    for i in xrange(Gr.dims.npg):
-                        DV.values[whor_rk0_shift+i] = 0.0
-                        DV.values[wpress_rk0_shift+i] = 0.0
-                        DV.values[whor_rk1_shift+i] = 0.0
-                        DV.values[wpress_rk1_shift+i] = 0.0
-                        DV.values[whor_rk2_shift+i] = 0.0
-                        DV.values[wpress_rk2_shift+i] = 0.0
+                    DV.values[whor_rk0_shift:whor_rk0_shift+Gr.dims.npg] = 0.0
+                    DV.values[wpress_rk0_shift:wpress_rk0_shift+Gr.dims.npg] = 0.0
+                    DV.values[whor_rk1_shift:whor_rk1_shift+Gr.dims.npg] = 0.0
+                    DV.values[wpress_rk01_shift:wpress_rk1_shift+Gr.dims.npg] = 0.0
+                    DV.values[whor_rk2_shift:whor_rk2_shift+Gr.dims.npg] = 0.0
+                    DV.values[wpress_rk02_shift:wpress_rk2_shift+Gr.dims.npg] = 0.0
+                    DV.values[whor_rk3_shift:whor_rk3_shift+Gr.dims.npg] = 0.0
+                    DV.values[wpress_rk03_shift:wpress_rk3_shift+Gr.dims.npg] = 0.0
+                    DV.values[whor_rk4_shift:whor_rk4_shift+Gr.dims.npg] = 0.0
+                    DV.values[wpress_rk04_shift:wpress_rk4_shift+Gr.dims.npg] = 0.0
+                    # for i in xrange(Gr.dims.npg):
+                    #     DV.values[whor_rk0_shift+i] = 0.0
+                    #     DV.values[wpress_rk0_shift+i] = 0.0
+                    #     DV.values[whor_rk1_shift+i] = 0.0
+                    #     DV.values[wpress_rk1_shift+i] = 0.0
+                    #     DV.values[whor_rk2_shift+i] = 0.0
+                    #     DV.values[wpress_rk2_shift+i] = 0.0
 
                 for i in xrange(Gr.dims.npg):
                     DV.values[whor_rk0_shift+i] += DV.values[whor_shift+i]

--- a/TimeStepping.pyx
+++ b/TimeStepping.pyx
@@ -62,7 +62,11 @@ cdef class TimeStepping:
             Pa.root_print('t_max (time at end of simulation) not given in name list! Killing Simulation Now')
             Pa.kill()
 
-        
+        try:
+            self.statIOdt = namelist['stats_io']['frequency']
+        except:
+            Pa.root_print('statsIOfrequency set to dt_max')
+            self.statIOdt = self.dt_max
 
         #Now initialize the correct time stepping routine
         if self.ts_type == 2:
@@ -160,7 +164,7 @@ cdef class TimeStepping:
 
         with nogil:
             if self.rk_step == 0:
-                if self.t % self.dt_max == 0.0:
+                if self.t % self.statIOdt == 0.0:
                     for i in xrange(Gr.dims.npg):
                         DV.values[whor_rk0_shift+i] = 0.0
                         DV.values[wpress_rk0_shift+i] = 0.0
@@ -222,7 +226,7 @@ cdef class TimeStepping:
 
         with nogil:
             if self.rk_step == 0:
-                if self.t % self.dt_max == 0.0:
+                if self.t % self.statIOdt == 0.0:
                     for i in xrange(Gr.dims.npg):
                         DV.values[whor_rk0_shift+i] = 0.0
                         DV.values[wpress_rk0_shift+i] = 0.0
@@ -319,7 +323,7 @@ cdef class TimeStepping:
 
         with nogil:
             if self.rk_step == 0:
-                if self.t % self.dt_max == 0.0:
+                if self.t % self.statIOdt == 0.0:
                     for i in xrange(Gr.dims.npg):
                         DV.values[whor_rk0_shift+i] = 0.0
                         DV.values[wpress_rk0_shift+i] = 0.0

--- a/TimeStepping.pyx
+++ b/TimeStepping.pyx
@@ -299,18 +299,21 @@ cdef class TimeStepping:
             Py_ssize_t whor_rk1_shift = DV.get_varshift(Gr, 'wBudget_removeHorAve_RK1')
             Py_ssize_t whor_rk2_shift = DV.get_varshift(Gr, 'wBudget_removeHorAve_RK2')
             Py_ssize_t whor_rk3_shift = DV.get_varshift(Gr, 'wBudget_removeHorAve_RK3')
+            Py_ssize_t whor_rk4_shift = DV.get_varshift(Gr, 'wBudget_removeHorAve_RK4')
 
             Py_ssize_t wpress_shift = DV.get_varshift(Gr, 'wBudget_PressureGradient')
             Py_ssize_t wpress_rk0_shift = DV.get_varshift(Gr, 'wBudget_PressureGradient_RK0')
             Py_ssize_t wpress_rk1_shift = DV.get_varshift(Gr, 'wBudget_PressureGradient_RK1')
             Py_ssize_t wpress_rk2_shift = DV.get_varshift(Gr, 'wBudget_PressureGradient_RK2')
             Py_ssize_t wpress_rk3_shift = DV.get_varshift(Gr, 'wBudget_PressureGradient_RK3')
+            Py_ssize_t wpress_rk4_shift = DV.get_varshift(Gr, 'wBudget_PressureGradient_RK4')
 
             double a1, a2, a3
 
         a1 = 0.386708617503269
         a2 = 0.096059710526147+a1*0.821920045606868
         a3 = 0.517231671970585+a2*0.379898148511597
+        a4 = 0.555629506348765*a3
 
         with nogil:
             if self.rk_step == 0:
@@ -352,8 +355,9 @@ cdef class TimeStepping:
                     DV.values[whor_shift+i] = (DV.values[whor_rk3_shift+i] + a1*DV.values[whor_rk2_shift+i]
                                                + a2*DV.values[whor_rk1_shift+i] + a3*DV.values[whor_rk0_shift+i] )
 
-                    DV.values[wpress_shift+i] = (DV.values[wpress_rk3_shift+i] + a1*DV.values[wpress_rk2_shift+i]
-                                               + a2*DV.values[wpress_rk1_shift+i] + a3*DV.values[wpress_rk0_shift+i] )
+                    DV.values[wpress_shift+i] = (DV.values[wpress_rk4_shift+i] + a1*DV.values[wpress_rk3_shift+i]
+                                               + a2*DV.values[wpress_rk2_shift+i] + a3*DV.values[wpress_rk1_shift+i]
+                                               + a4*DV.values[wpress_rk0_shift+i] )
 
         return
 

--- a/Tracers.pyx
+++ b/Tracers.pyx
@@ -435,8 +435,8 @@ cdef class UpdraftTracers:
                         u_half[ijk] = 0.5 * (PV.values[u_shift+ijk-istride] + PV.values[u_shift+ijk])
                         v_half[ijk] = 0.5 * (PV.values[v_shift+ijk-jstride] + PV.values[v_shift+ijk])
                         w_half[ijk] = 0.5 * (PV.values[w_shift+ijk-1] + PV.values[w_shift+ijk])
-                        wpz_half[ijk] = 0.5 * (PV.values[pz_shift+ijk-1] + PV.values[pz_shift+ijk])
-                        whor_half[ijk] = 0.5 * (PV.values[whor_shift+ijk-1] + PV.values[whor_shift+ijk])
+                        wpz_half[ijk] = 0.5 * (DV.values[pz_shift+ijk-1] + DV.values[pz_shift+ijk])
+                        whor_half[ijk] = 0.5 * (DV.values[whor_shift+ijk-1] + DV.values[whor_shift+ijk])
 
         tmp = Pa.HorizontalMean(Gr, &self.updraft_indicator[0])
         NS.write_profile('updraft_fraction', tmp[Gr.dims.gw:-Gr.dims.gw], Pa)

--- a/Tracers.pyx
+++ b/Tracers.pyx
@@ -385,6 +385,10 @@ cdef class UpdraftTracers:
             double [:] u_half = np.zeros((Gr.dims.npg),dtype=np.double, order='c')
             double [:] v_half = np.zeros((Gr.dims.npg),dtype=np.double, order='c')
             double [:] w_half = np.zeros((Gr.dims.npg),dtype=np.double, order='c')
+
+            double [:] wpz_half = np.zeros((Gr.dims.npg),dtype=np.double, order='c')
+            double [:] whor_half = np.zeros((Gr.dims.npg),dtype=np.double, order='c')
+
             double [:] mean = Pa.HorizontalMean(Gr, &PV.values[c_shift])
             double [:] mean_square = Pa.HorizontalMeanofSquares(Gr, &PV.values[c_shift], &PV.values[c_shift])
             Py_ssize_t i,j,k, ijk, ishift, jshift
@@ -431,6 +435,8 @@ cdef class UpdraftTracers:
                         u_half[ijk] = 0.5 * (PV.values[u_shift+ijk-istride] + PV.values[u_shift+ijk])
                         v_half[ijk] = 0.5 * (PV.values[v_shift+ijk-jstride] + PV.values[v_shift+ijk])
                         w_half[ijk] = 0.5 * (PV.values[w_shift+ijk-1] + PV.values[w_shift+ijk])
+                        wpz_half[ijk] = 0.5 * (PV.values[pz_shift+ijk-1] + PV.values[pz_shift+ijk])
+                        whor_half[ijk] = 0.5 * (PV.values[whor_shift+ijk-1] + PV.values[whor_shift+ijk])
 
         tmp = Pa.HorizontalMean(Gr, &self.updraft_indicator[0])
         NS.write_profile('updraft_fraction', tmp[Gr.dims.gw:-Gr.dims.gw], Pa)
@@ -451,6 +457,14 @@ cdef class UpdraftTracers:
         tmp = Pa.HorizontalMeanofSquaresConditional(Gr,&v_half[0], &v_half[0], &self.updraft_indicator[0])
         NS.write_profile('updraft_v2', tmp[Gr.dims.gw:-Gr.dims.gw], Pa)
 
+        tmp = Pa.HorizontalMeanConditional(Gr, &DV.values[press_shift], &self.updraft_indicator[0])
+        NS.write_profile('updraft_density_perturbation_pressure', tmp[Gr.dims.gw:-Gr.dims.gw], Pa)
+
+        tmp = Pa.HorizontalMeanConditional(Gr, &wpz_half[0], &self.updraft_indicator[0])
+        NS.write_profile('updraft_wBudget_PressureGradient', tmp[Gr.dims.gw:-Gr.dims.gw], Pa)
+        tmp = Pa.HorizontalMeanConditional(Gr, &whor_half[0], &self.updraft_indicator[0])
+        NS.write_profile('updraft_wBudget_removeHorAve', tmp[Gr.dims.gw:-Gr.dims.gw], Pa)
+
         tmp = Pa.HorizontalMeanConditional(Gr, &PV.values[q_shift], &self.updraft_indicator[0])
         NS.write_profile('updraft_qt', tmp[Gr.dims.gw:-Gr.dims.gw], Pa)
         tmp = Pa.HorizontalMeanofSquaresConditional(Gr, &PV.values[q_shift], &PV.values[q_shift], &self.updraft_indicator[0])
@@ -470,12 +484,6 @@ cdef class UpdraftTracers:
         tmp = Pa.HorizontalMeanofSquaresConditional(Gr, &DV.values[b_shift], &DV.values[b_shift], &self.updraft_indicator[0])
         NS.write_profile('updraft_b2', tmp[Gr.dims.gw:-Gr.dims.gw], Pa)
 
-        tmp = Pa.HorizontalMeanConditional(Gr, &DV.values[press_shift], &self.updraft_indicator[0])
-        NS.write_profile('updraft_density_perturbation_pressure', tmp[Gr.dims.gw:-Gr.dims.gw], Pa)
-        tmp = Pa.HorizontalMeanConditional(Gr, &DV.values[pz_shift], &self.updraft_indicator[0])
-        NS.write_profile('updraft_wBudget_PressureGradient', tmp[Gr.dims.gw:-Gr.dims.gw], Pa)
-        tmp = Pa.HorizontalMeanConditional(Gr, &DV.values[whor_shift], &self.updraft_indicator[0])
-        NS.write_profile('updraft_wBudget_removeHorAve', tmp[Gr.dims.gw:-Gr.dims.gw], Pa)
 
         tmp = Pa.HorizontalMeanofSquaresConditional(Gr, &w_half[0], &PV.values[q_shift], &self.updraft_indicator[0])
         NS.write_profile('updraft_w_qt', tmp[Gr.dims.gw:-Gr.dims.gw], Pa)

--- a/Tracers.pyx
+++ b/Tracers.pyx
@@ -205,6 +205,13 @@ cdef class UpdraftTracers:
         NS.add_profile('env_thetarho', Gr, Pa, units=r'K', nice_name=r'\theta_{\rho,e}',
                        desc=r'environment density potential temperature')
 
+        NS.add_profile('updraft_density_dynamic_pressure', Gr, Pa, units=r'm^2 s^-2 ', nice_name=r'updraft alpha0 * dynamic pressure',
+                      desc=r'updraft alpha0 * dynamic pressure')
+        NS.add_profile('updraft_wBudget_PressureGradient', Gr, Pa, units=r'm/s', nice_name=r'updraft average of pressure gradient force',
+                      desc=r'updraft average of pressure gradient force')
+        NS.add_profile('updraft_wBudget_removeHorAve', Gr, Pa, units=r'm/s', nice_name=r'remove grid mean w',
+                     desc=r'remove grid mean w')
+
 
         if 'ql' in DV.name_index:
             NS.add_profile('updraft_ql', Gr, Pa, units=r'kg kg^{-1}',nice_name=r'q_{l,u}',
@@ -368,6 +375,9 @@ cdef class UpdraftTracers:
             Py_ssize_t bvf_shift = DV.get_varshift(Gr, 'buoyancy_frequency')
             Py_ssize_t thr_shift = DV.get_varshift(Gr, 'theta_rho')
             Py_ssize_t qv_shift = DV.get_varshift(Gr, 'qv')
+            Py_ssize_t press_shift = DV.get_varshift(Gr, 'density_dynamic_pressure')
+            Py_ssize_t pz_shift = DV.get_varshift(Gr, 'wBudget_PressureGradient')
+            Py_ssize_t whor_shift = DV.get_varshift(Gr, 'wBudget_removeHorAve')
             Py_ssize_t ql_shift, th_shift, qr_shift
             double [:] cloudfraction = np.zeros((Gr.dims.npg),dtype=np.double, order='c')
             double [:] tracer_normed = np.zeros((Gr.dims.npg),dtype=np.double, order='c')
@@ -459,6 +469,13 @@ cdef class UpdraftTracers:
         NS.write_profile('updraft_b', tmp[Gr.dims.gw:-Gr.dims.gw], Pa)
         tmp = Pa.HorizontalMeanofSquaresConditional(Gr, &DV.values[b_shift], &DV.values[b_shift], &self.updraft_indicator[0])
         NS.write_profile('updraft_b2', tmp[Gr.dims.gw:-Gr.dims.gw], Pa)
+
+        tmp = Pa.HorizontalMeanConditional(Gr, &DV.values[press_shift], &self.updraft_indicator[0])
+        NS.write_profile('updraft_density_dynamic_pressure', tmp[Gr.dims.gw:-Gr.dims.gw], Pa)
+        tmp = Pa.HorizontalMeanConditional(Gr, &DV.values[pz_shift], &self.updraft_indicator[0])
+        NS.write_profile('updraft_wBudget_PressureGradient', tmp[Gr.dims.gw:-Gr.dims.gw], Pa)
+        tmp = Pa.HorizontalMeanConditional(Gr, &DV.values[whor_shift], &self.updraft_indicator[0])
+        NS.write_profile('updraft_wBudget_removeHorAve', tmp[Gr.dims.gw:-Gr.dims.gw], Pa)
 
         tmp = Pa.HorizontalMeanofSquaresConditional(Gr, &w_half[0], &PV.values[q_shift], &self.updraft_indicator[0])
         NS.write_profile('updraft_w_qt', tmp[Gr.dims.gw:-Gr.dims.gw], Pa)

--- a/Tracers.pyx
+++ b/Tracers.pyx
@@ -205,9 +205,9 @@ cdef class UpdraftTracers:
         NS.add_profile('env_thetarho', Gr, Pa, units=r'K', nice_name=r'\theta_{\rho,e}',
                        desc=r'environment density potential temperature')
 
-        NS.add_profile('updraft_density_perturbation_pressure', Gr, Pa, units=r'm^2 s^-2 ', nice_name=r'updraft alpha0 * dynamic pressure',
-                      desc=r'updraft alpha0 * dynamic pressure')
-        NS.add_profile('updraft_wBudget_PressureGradient', Gr, Pa, units=r'm/s', nice_name=r'updraft average of pressure gradient force',
+        NS.add_profile('updraft_perturbation_pressure_potential', Gr, Pa, units=r'm^2 s^-2 ', nice_name=r'updraft alpha0 * perturbation pressure',
+                      desc=r'updraft alpha0 * perturbation pressure')
+        NS.add_profile('updraft_wBudget_PressureGradient', Gr, Pa, units=r'm/s', nice_name=r'updraft average of pressure gradient contribution',
                       desc=r'updraft average of pressure gradient force')
         NS.add_profile('updraft_wBudget_removeHorAve', Gr, Pa, units=r'm/s', nice_name=r'remove grid mean w',
                      desc=r'remove grid mean w')
@@ -375,7 +375,7 @@ cdef class UpdraftTracers:
             Py_ssize_t bvf_shift = DV.get_varshift(Gr, 'buoyancy_frequency')
             Py_ssize_t thr_shift = DV.get_varshift(Gr, 'theta_rho')
             Py_ssize_t qv_shift = DV.get_varshift(Gr, 'qv')
-            Py_ssize_t press_shift = DV.get_varshift(Gr, 'density_perturbation_pressure')
+            Py_ssize_t press_shift = DV.get_varshift(Gr, 'perturbation_pressure_potential')
             Py_ssize_t pz_shift = DV.get_varshift(Gr, 'wBudget_PressureGradient')
             Py_ssize_t whor_shift = DV.get_varshift(Gr, 'wBudget_removeHorAve')
             Py_ssize_t ql_shift, th_shift, qr_shift
@@ -458,7 +458,7 @@ cdef class UpdraftTracers:
         NS.write_profile('updraft_v2', tmp[Gr.dims.gw:-Gr.dims.gw], Pa)
 
         tmp = Pa.HorizontalMeanConditional(Gr, &DV.values[press_shift], &self.updraft_indicator[0])
-        NS.write_profile('updraft_density_perturbation_pressure', tmp[Gr.dims.gw:-Gr.dims.gw], Pa)
+        NS.write_profile('updraft_perturbation_pressure_potential', tmp[Gr.dims.gw:-Gr.dims.gw], Pa)
 
         tmp = Pa.HorizontalMeanConditional(Gr, &wpz_half[0], &self.updraft_indicator[0])
         NS.write_profile('updraft_wBudget_PressureGradient', tmp[Gr.dims.gw:-Gr.dims.gw], Pa)

--- a/Tracers.pyx
+++ b/Tracers.pyx
@@ -906,7 +906,7 @@ cdef updraft_indicator_sc(Grid.DimStruct *dims, double *tracer_raw, double *trac
                     for j in xrange(jmax):
                         jshift = j*jstride
                         ijk = ishift + jshift + k
-                        tracer_normed[ijk] = (tracer_raw[ijk] - mean[k])/ sigma_min
+                        tracer_normed[ijk] = 0.0
             else:
                for i in xrange(imax):
                     ishift = i*istride
@@ -945,7 +945,7 @@ cdef updraft_indicator_sc_w(Grid.DimStruct *dims, double *tracer_raw, double *tr
                     for j in xrange(jmax):
                         jshift = j*jstride
                         ijk = ishift + jshift + k
-                        tracer_normed[ijk] = copysign( (tracer_raw[ijk] - mean[k])/ sigma_min, w_half)
+                        tracer_normed[ijk] = 0.0
             else:
                for i in xrange(imax):
                     ishift = i*istride
@@ -981,7 +981,7 @@ cdef updraft_indicator_sc_w_ql(Grid.DimStruct *dims,  double *tracer_raw, double
                     for j in xrange(dims.nlg[1]):
                         jshift = j*jstride
                         ijk = ishift + jshift + k
-                        tracer_normed[ijk] = copysign( (tracer_raw[ijk] - mean[k])/ sigma_min, w_half)
+                        tracer_normed[ijk] = 0.0
             else:
                for i in xrange(dims.nlg[0]):
                     ishift = i*istride

--- a/Tracers.pyx
+++ b/Tracers.pyx
@@ -906,7 +906,7 @@ cdef updraft_indicator_sc(Grid.DimStruct *dims, double *tracer_raw, double *trac
                     for j in xrange(jmax):
                         jshift = j*jstride
                         ijk = ishift + jshift + k
-                        tracer_normed[ijk] = 0.0
+                        tracer_normed[ijk] = (tracer_raw[ijk] - mean[k])/ sigma_min
             else:
                for i in xrange(imax):
                     ishift = i*istride
@@ -945,7 +945,9 @@ cdef updraft_indicator_sc_w(Grid.DimStruct *dims, double *tracer_raw, double *tr
                     for j in xrange(jmax):
                         jshift = j*jstride
                         ijk = ishift + jshift + k
-                        tracer_normed[ijk] = 0.0
+                        w_half = 0.5*(w[ijk-1] + w[ijk])
+                        # tracer_normed[ijk] = 0.0
+                        tracer_normed[ijk] = copysign( (tracer_raw[ijk] - mean[k])/ sigma_min, w_half)
             else:
                for i in xrange(imax):
                     ishift = i*istride
@@ -981,7 +983,9 @@ cdef updraft_indicator_sc_w_ql(Grid.DimStruct *dims,  double *tracer_raw, double
                     for j in xrange(dims.nlg[1]):
                         jshift = j*jstride
                         ijk = ishift + jshift + k
-                        tracer_normed[ijk] = 0.0
+                        w_half = 0.5*(w[ijk-1] + w[ijk])
+                        # tracer_normed[ijk] = 0.0
+                        tracer_normed[ijk] = copysign( (tracer_raw[ijk] - mean[k])/ sigma_min, w_half)
             else:
                for i in xrange(dims.nlg[0]):
                     ishift = i*istride

--- a/Tracers.pyx
+++ b/Tracers.pyx
@@ -205,7 +205,7 @@ cdef class UpdraftTracers:
         NS.add_profile('env_thetarho', Gr, Pa, units=r'K', nice_name=r'\theta_{\rho,e}',
                        desc=r'environment density potential temperature')
 
-        NS.add_profile('updraft_density_dynamic_pressure', Gr, Pa, units=r'm^2 s^-2 ', nice_name=r'updraft alpha0 * dynamic pressure',
+        NS.add_profile('updraft_density_perturbation_pressure', Gr, Pa, units=r'm^2 s^-2 ', nice_name=r'updraft alpha0 * dynamic pressure',
                       desc=r'updraft alpha0 * dynamic pressure')
         NS.add_profile('updraft_wBudget_PressureGradient', Gr, Pa, units=r'm/s', nice_name=r'updraft average of pressure gradient force',
                       desc=r'updraft average of pressure gradient force')
@@ -375,7 +375,7 @@ cdef class UpdraftTracers:
             Py_ssize_t bvf_shift = DV.get_varshift(Gr, 'buoyancy_frequency')
             Py_ssize_t thr_shift = DV.get_varshift(Gr, 'theta_rho')
             Py_ssize_t qv_shift = DV.get_varshift(Gr, 'qv')
-            Py_ssize_t press_shift = DV.get_varshift(Gr, 'density_dynamic_pressure')
+            Py_ssize_t press_shift = DV.get_varshift(Gr, 'density_perturbation_pressure')
             Py_ssize_t pz_shift = DV.get_varshift(Gr, 'wBudget_PressureGradient')
             Py_ssize_t whor_shift = DV.get_varshift(Gr, 'wBudget_removeHorAve')
             Py_ssize_t ql_shift, th_shift, qr_shift
@@ -471,7 +471,7 @@ cdef class UpdraftTracers:
         NS.write_profile('updraft_b2', tmp[Gr.dims.gw:-Gr.dims.gw], Pa)
 
         tmp = Pa.HorizontalMeanConditional(Gr, &DV.values[press_shift], &self.updraft_indicator[0])
-        NS.write_profile('updraft_density_dynamic_pressure', tmp[Gr.dims.gw:-Gr.dims.gw], Pa)
+        NS.write_profile('updraft_density_perturbation_pressure', tmp[Gr.dims.gw:-Gr.dims.gw], Pa)
         tmp = Pa.HorizontalMeanConditional(Gr, &DV.values[pz_shift], &self.updraft_indicator[0])
         NS.write_profile('updraft_wBudget_PressureGradient', tmp[Gr.dims.gw:-Gr.dims.gw], Pa)
         tmp = Pa.HorizontalMeanConditional(Gr, &DV.values[whor_shift], &self.updraft_indicator[0])

--- a/Tracers.pyx
+++ b/Tracers.pyx
@@ -946,7 +946,6 @@ cdef updraft_indicator_sc_w(Grid.DimStruct *dims, double *tracer_raw, double *tr
                         jshift = j*jstride
                         ijk = ishift + jshift + k
                         w_half = 0.5*(w[ijk-1] + w[ijk])
-                        # tracer_normed[ijk] = 0.0
                         tracer_normed[ijk] = copysign( (tracer_raw[ijk] - mean[k])/ sigma_min, w_half)
             else:
                for i in xrange(imax):
@@ -984,7 +983,6 @@ cdef updraft_indicator_sc_w_ql(Grid.DimStruct *dims,  double *tracer_raw, double
                         jshift = j*jstride
                         ijk = ishift + jshift + k
                         w_half = 0.5*(w[ijk-1] + w[ijk])
-                        # tracer_normed[ijk] = 0.0
                         tracer_normed[ijk] = copysign( (tracer_raw[ijk] - mean[k])/ sigma_min, w_half)
             else:
                for i in xrange(dims.nlg[0]):


### PR DESCRIPTION
1. change the variables name "dynamic pressure" to "density perturbation pressure" to clarify that this diagnostic variables is calculated for "p' * alpha"

2. In update_pressure function, at the end of each timestep, divide "density perturbation pressure" by dt. This is because the Poisson solver is actually solving for "p' * alpha * dt". 

3. The perturbation pressure gradient as a source/sink term in the w equation is computed as saved as a diagnostic variable. It is can be extract as a diagnostic variable in field data and is automatically saved in tracer.